### PR TITLE
Fix Brusselator right-hand side in some examples

### DIFF
--- a/bench/runbenchmarks.jl
+++ b/bench/runbenchmarks.jl
@@ -10,7 +10,7 @@ u0 = [0.2, 0.03]
 function Brusselator!(du, u, p, t)
     a, μ = 1, 4
     du[1] = a - (μ + 1) * u[1] + (u[1])^2 * u[2]
-    return du[2] = μ * u[1] - (u[1])^2 * u[1]
+    return du[2] = μ * u[1] - (u[1])^2 * u[2]
 end
 
 prob = FODEProblem(Brusselator!, α, u0, (0, 20))

--- a/docs/ChaosGallery/Gallery/Brusselator.md
+++ b/docs/ChaosGallery/Gallery/Brusselator.md
@@ -3,7 +3,7 @@
 ```math
 \begin{cases}
 {_{t_0}D_t^\alpha}y_1(t)=a-(\mu+1)y_1(t)+(y_1(t))^2y_2(t)\\
-{_{t_0}D_t^\alpha}y_2(t)=\mu y_1(t)-(y_1(t))^2y_1(t)\\
+{_{t_0}D_t^\alpha}y_2(t)=\mu y_1(t)-(y_1(t))^2y_2(t)\\
 y_1(t_0)=y_{1,0}\\
 y_2(t_0)=y_{2,0}
 \end{cases}
@@ -20,7 +20,7 @@ tspan = (0, 100)
 function Brusselator!(du, u, p, t)
     a, μ = 1, 4
     du[1] = a-(μ+1)*u[1]+(u[1])^2*u[2]
-    du[2] = μ*u[1]-(u[1])^2*u[1]
+    du[2] = μ*u[1]-(u[1])^2*u[2]
 end
 
 prob = FODEProblem(Brusselator!, α, u0, tspan)

--- a/examples/Brusselator.jl
+++ b/examples/Brusselator.jl
@@ -7,7 +7,7 @@ h = 0.001
 function Brusselator!(du, u, p, t)
     a, μ = 1, 4
     du[1] = a - (μ + 1) * u[1] + (u[1])^2 * u[2]
-    du[2] = μ * u[1] - (u[1])^2 * u[1]
+    du[2] = μ * u[1] - (u[1])^2 * u[2]
 end
 
 prob = FODESystem(Brusselator!, α, u0, (0, 100))


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Brusselator, the second row in the Brusselator right-hand side is $\mu u_1 - u_1^2 \mathbf{u_2}$. This fixes some of the places this was incorrectly written (e.g. `test/fode.jl` uses the correct formula).

I mostly noticed this from looking at the chaotic systems gallery, so that image will also have to be updated :grin: 